### PR TITLE
[feat] update sender

### DIFF
--- a/src/lib/anotherback.js
+++ b/src/lib/anotherback.js
@@ -71,7 +71,7 @@ export default class Anotherback{
 		});
 
 		await this.app.register(cookie, {hook: "onRequest", ...this.#registerParamsCookie});
-		await this.app.register(cors, {credentials: true, ...this.#registerParamsCors});
+		await this.app.register(cors, {credentials: true, ...this.#registerParamsCors, exposedHeaders: ["aob-info", ...(this.#registerParamsCors.exposedHeaders || [])]});
 
 		for(const reg of this.snack.register) await this.app.register(reg);
 		

--- a/src/lib/ctx.js
+++ b/src/lib/ctx.js
@@ -27,13 +27,13 @@ export class AccessCtx{
 		return this.#pass.handler(key, value);
 	}
 
-	async otherAccess(name){
+	async otherAccess(name, exec = false){
 		try {
 			await Anotherback.snack.accesses[name].call(this, this.req);
 			return true;
 		}
 		catch (error){
-			if(error instanceof Sender) return false;
+			if(error instanceof Sender && exec !== true) return false;
 			else throw error;
 		}
 	}

--- a/src/lib/sender.js
+++ b/src/lib/sender.js
@@ -5,7 +5,10 @@ export default class Sender{
 
 	async exec(res){
 		let result = await this.fnc(res, this.info, this.data);
-		if(result !== undefined)res.status(result.code || 200).send({i: result.info, d: result.data});
+		if(result !== undefined){
+			res.header("aob-info", result.info || undefined);
+			res.status(result.code || 200).send(result.data || undefined);
+		}
 	}
 
 	init(info, data){


### PR DESCRIPTION
l'info passe maintenant par leader ce qui permet de renvoyer une info lors d'une réponse 204 + plus ajout d'un paramètre d'auto exécution d'un sender en cas d'échec d'un "otherAccess"

close #38 
close #39 